### PR TITLE
fix: don't ignore hotkeys with letters S, C, A, M

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,7 @@ export class KeyboardService {
   }
 
   handleKey = (e: KeyboardEvent) => {
-    if (modifiers[e.key.toLowerCase()]) return;
+    if (e.key.length > 1 && modifiers[e.key.toLowerCase()]) return;
     this._resetTimer();
     const keyCS = reprKey(e.key, {
       c: e.ctrlKey,


### PR DESCRIPTION
Maybe there are more places that should be fixed, I don't know.